### PR TITLE
fix: correct product href in cart items

### DIFF
--- a/src/app/cart/cart-items.tsx
+++ b/src/app/cart/cart-items.tsx
@@ -54,7 +54,7 @@ export async function CartItems({activeOrder}: { activeOrder: ActiveOrder | null
                 >
                     {line.productVariant.product.featuredAsset && (
                         <Link
-                            href={`/src/app/%5Blocale%5D/product/${line.productVariant.product.slug}`}
+                            href={`/product/${line.productVariant.product.slug}`}
                             className="flex-shrink-0"
                         >
                             <Image
@@ -69,7 +69,7 @@ export async function CartItems({activeOrder}: { activeOrder: ActiveOrder | null
 
                     <div className="flex-grow min-w-0">
                         <Link
-                            href={`/src/app/%5Blocale%5D/product/${line.productVariant.product.slug}`}
+                            href={`/product/${line.productVariant.product.slug}`}
                             className="font-semibold hover:underline block"
                         >
                             {line.productVariant.product.name}


### PR DESCRIPTION
The product link were using an incorrect path(/src/app/%5Blocale%5D/product/...), changed to the correct route (/product/...) to avoid 404.