### PR TITLE
chore: enforce minimum dependency age and disable lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,11 @@
+# Supply-chain hardening:
+#   - `min-release-age` defers installation of any package version published
+#     less than 7 days ago, defeating the typical "publish-malware,
+#     worm-spreads-fast, maintainer-yanks-within-48h" attack pattern.
+#     Requires npm >= 11.10. Older npm versions will silently ignore this.
+#   - `ignore-scripts=true` blocks lifecycle scripts (preinstall / install /
+#     postinstall) of dependencies — the primary execution vector for
+#     malicious packages.
+# See https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
+min-release-age=7
+ignore-scripts=true


### PR DESCRIPTION
Adds `.npmrc` with our two-setting supply-chain hardening policy:

- **`min-release-age=7`** — refuse to install any package version published less than 7 days ago. Defeats the npm supply-chain attack pattern (e.g. Shai-Hulud) where a poisoned version is live for a few hours before being yanked. Requires npm >= 11.10; older npm silently ignores it.
- **`ignore-scripts=true`** — block lifecycle scripts (`preinstall` / `install` / `postinstall`) of dependencies. Primary execution vector for malicious packages.

This repo has no native deps that rely on lifecycle scripts, so `ignore-scripts=true` is safe to enable globally.

## Refs

- Policy + repo survey: [Notion: Supply Chain Security](https://www.notion.so/vendurehq/Supply-Chain-Security-351d67bac45a808f894ac4efc4fc8154)
- Original investigation in core: vendurehq/vendure#4674

## Test plan

- [x] `npm install` still succeeds locally on npm >= 11.10
- [x] No CI breakage