### PR TITLE
fix: add password show/hide toggle to all auth forms

### DIFF
--- a/src/app/[locale]/account/profile/change-password-form.tsx
+++ b/src/app/[locale]/account/profile/change-password-form.tsx
@@ -3,8 +3,8 @@
 import { useActionState, useEffect } from 'react';
 import { updatePasswordAction } from './actions';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {useTranslations} from 'next-intl';
 
@@ -31,10 +31,9 @@ export function ChangePasswordForm() {
                 <CardContent className="space-y-4">
                     <div className="space-y-2">
                         <Label htmlFor="currentPassword">{t('currentPassword')}</Label>
-                        <Input
+                        <PasswordInput
                             id="currentPassword"
                             name="currentPassword"
-                            type="password"
                             placeholder="••••••••"
                             required
                             disabled={isPending}
@@ -42,10 +41,9 @@ export function ChangePasswordForm() {
                     </div>
                     <div className="space-y-2">
                         <Label htmlFor="newPassword">{t('newPassword')}</Label>
-                        <Input
+                        <PasswordInput
                             id="newPassword"
                             name="newPassword"
-                            type="password"
                             placeholder="••••••••"
                             required
                             disabled={isPending}
@@ -53,10 +51,9 @@ export function ChangePasswordForm() {
                     </div>
                     <div className="space-y-2">
                         <Label htmlFor="confirmPassword">{t('confirmNewPassword')}</Label>
-                        <Input
+                        <PasswordInput
                             id="confirmPassword"
                             name="confirmPassword"
-                            type="password"
                             placeholder="••••••••"
                             required
                             disabled={isPending}

--- a/src/app/[locale]/account/profile/edit-email-form.tsx
+++ b/src/app/[locale]/account/profile/edit-email-form.tsx
@@ -5,6 +5,7 @@ import { requestEmailUpdateAction } from './actions';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {useTranslations} from 'next-intl';
 
@@ -56,10 +57,9 @@ export function EditEmailForm({ currentEmail }: EditEmailFormProps) {
                     </div>
                     <div className="space-y-2">
                         <Label htmlFor="password">{t('currentPassword')}</Label>
-                        <Input
+                        <PasswordInput
                             id="password"
                             name="password"
-                            type="password"
                             placeholder="••••••••"
                             required
                             disabled={isPending}

--- a/src/app/[locale]/register/registration-form.tsx
+++ b/src/app/[locale]/register/registration-form.tsx
@@ -7,6 +7,7 @@ import * as z from 'zod';
 import { registerAction } from './actions';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import {
     Form,
@@ -172,8 +173,7 @@ export function RegistrationForm({ redirectTo }: RegistrationFormProps) {
                                 <FormItem>
                                     <FormLabel>{t('passwordLabel')}</FormLabel>
                                     <FormControl>
-                                        <Input
-                                            type="password"
+                                        <PasswordInput
                                             placeholder="••••••••"
                                             disabled={isPending}
                                             {...field}
@@ -191,8 +191,7 @@ export function RegistrationForm({ redirectTo }: RegistrationFormProps) {
                                 <FormItem>
                                     <FormLabel>{t('confirmPasswordLabel')}</FormLabel>
                                     <FormControl>
-                                        <Input
-                                            type="password"
+                                        <PasswordInput
                                             placeholder="••••••••"
                                             disabled={isPending}
                                             {...field}

--- a/src/app/[locale]/reset-password/reset-password-form.tsx
+++ b/src/app/[locale]/reset-password/reset-password-form.tsx
@@ -3,8 +3,8 @@
 import { use, useActionState } from 'react';
 import { resetPasswordAction } from './actions';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { PasswordInput } from '@/components/ui/password-input';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Link } from '@/i18n/navigation';
 import {useTranslations} from 'next-intl';
@@ -53,10 +53,9 @@ export function ResetPasswordForm({ searchParams }: ResetPasswordFormProps) {
                 <CardContent className="space-y-4">
                     <div className="space-y-2">
                         <Label htmlFor="password">{t('newPassword')}</Label>
-                        <Input
+                        <PasswordInput
                             id="password"
                             name="password"
-                            type="password"
                             placeholder="••••••••"
                             required
                             disabled={isPending}
@@ -64,10 +63,9 @@ export function ResetPasswordForm({ searchParams }: ResetPasswordFormProps) {
                     </div>
                     <div className="space-y-2">
                         <Label htmlFor="confirmPassword">{t('confirmPassword')}</Label>
-                        <Input
+                        <PasswordInput
                             id="confirmPassword"
                             name="confirmPassword"
-                            type="password"
                             placeholder="••••••••"
                             required
                             disabled={isPending}

--- a/src/app/[locale]/sign-in/login-form.tsx
+++ b/src/app/[locale]/sign-in/login-form.tsx
@@ -7,6 +7,7 @@ import * as z from 'zod';
 import {loginAction} from './actions';
 import {Button} from '@/components/ui/button';
 import {Input} from '@/components/ui/input';
+import {PasswordInput} from '@/components/ui/password-input';
 import {Card, CardContent, CardFooter} from '@/components/ui/card';
 import {
     Form,
@@ -105,8 +106,7 @@ export function LoginForm({redirectTo}: LoginFormProps) {
                                     </div>
 
                                     <FormControl>
-                                        <Input
-                                            type="password"
+                                        <PasswordInput
                                             placeholder="••••••••"
                                             disabled={isPending}
                                             {...field}

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import * as React from "react"
+import { Eye, EyeOff } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+
+function PasswordInput({ className, disabled, ...props }: Omit<React.ComponentProps<"input">, "type">) {
+    const [showPassword, setShowPassword] = React.useState(false)
+
+    return (
+        <div className="relative">
+            <Input
+                type={showPassword ? "text" : "password"}
+                className={cn("pr-10", className)}
+                disabled={disabled}
+                {...props}
+            />
+            <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => setShowPassword((prev) => !prev)}
+                aria-label={showPassword ? "Hide password" : "Show password"}
+                disabled={disabled}
+                tabIndex={-1}
+                className="absolute inset-y-0 right-1 my-auto text-muted-foreground hover:text-foreground"
+            >
+                {showPassword ? (
+                    <EyeOff className="size-4" />
+                ) : (
+                    <Eye className="size-4" />
+                )}
+            </Button>
+        </div>
+    )
+}
+
+export { PasswordInput }


### PR DESCRIPTION
## Problem

All password fields across the storefront have no visibility toggle.
Users cannot verify what they typed, which leads to failed logins and
registration frustration — especially on mobile.

Affected forms:
- Sign-in
- Registration (password + confirm password)
- Reset password (new password + confirm)
- Change password (current + new + confirm)
- Edit email (password confirmation)

## Solution

Added a reusable `PasswordInput` component (`src/components/ui/password-input.tsx`)
that wraps the existing `Input` with an Eye/EyeOff toggle button. Uses the
project's existing `Button` (variant ghost) and `lucide-react` icons — no new
dependencies.

## Changes

- `src/components/ui/password-input.tsx` — new reusable component
- 5 form files — swap `<Input type="password">` → `<PasswordInput>`

## Notes

- Toggle button has `tabIndex={-1}` to preserve keyboard flow
- Button and input share the same `disabled` state
- Follows existing UI component patterns (plain function, double quotes, named export)

Closes #25 

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/nextjs-starter-vendure/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->