### PR TITLE
fix: correct variant option highlight selector for Base UI

### DIFF
--- a/src/components/commerce/product-info.tsx
+++ b/src/components/commerce/product-info.tsx
@@ -181,7 +181,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
                                             />
                                             <Label
                                                 htmlFor={option.id}
-                                                className="flex items-center justify-center rounded-lg border-2 border-muted bg-popover px-4 py-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground peer-data-[state=checked]:border-primary peer-data-[state=checked]:ring-2 peer-data-[state=checked]:ring-primary/20 peer-data-[state=checked]:bg-primary/5 cursor-pointer transition-all"
+                                                className="flex items-center justify-center rounded-lg border-2 border-muted bg-popover px-4 py-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground peer-data-[checked]:border-primary peer-data-[checked]:ring-2 peer-data-[checked]:ring-primary/20 peer-data-[checked]:bg-primary/5 cursor-pointer transition-all"
                                             >
                                                 {option.name}
                                             </Label>


### PR DESCRIPTION
## Problem
Variant option buttons had no visual feedback when selected.
The peer selectors were written for Radix UI (`peer-data-[state=checked]`)
but the project uses Base UI which sets `data-checked` — so they never matched.

## Fix
Replace `peer-data-[state=checked]:` → `peer-data-[checked]:` in the
Label className in `product-info.tsx`.

Video (Before Fix)


https://github.com/user-attachments/assets/739ff40a-b615-409a-8fa6-1ab8258dc80f

Video (After Fix)

https://github.com/user-attachments/assets/b598a43c-e9f4-4fd8-acb6-36e908d82caf

Fixes Issue #28

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/nextjs-starter-vendure/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781946581&installation_id=128408429&pr_number=29&repository=vendurehq%2Fnextjs-starter-vendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fnextjs-starter-vendure%2Fpull%2F29&signature=2df6b0f9d268980a4d57affa650bb98c6c8fec67622f361ec92461dbe5f5ba66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->