### PR TITLE
fix: filter variant options to only those with a matching variant

### DIFF
--- a/src/components/commerce/product-info.tsx
+++ b/src/components/commerce/product-info.tsx
@@ -172,7 +172,9 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
                                 onValueChange={(value) => handleOptionChange(group.id, value)}
                             >
                                 <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                                    {group.options.map((option) => (
+                                    {group.options.filter((option) =>
+                                        product.variants.some((v) => v.options.some((o) => o.id === option.id))
+                                    ).map((option) => (
                                         <div key={option.id}>
                                             <RadioGroupItem
                                                 value={option.id}


### PR DESCRIPTION
## Problem

The product page renders option buttons from `optionGroups.options`.
When using Vendure's global/shared option groups, this causes options
with no corresponding variant on the product to appear as clickable
buttons — showing no price, no stock status, and a broken add-to-cart.

## Fix

Filter `group.options` to only those that have a matching variant
before rendering. This ensures correct behaviour for both per-product
and global/shared option groups.

## Change

`product-info.tsx` — 1 file, 1 line filter added

Fixes #30

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/nextjs-starter-vendure/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781955682&installation_id=128408429&pr_number=31&repository=vendurehq%2Fnextjs-starter-vendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fnextjs-starter-vendure%2Fpull%2F31&signature=e146d06de2ff2a0e297eae89e7d7d6988caf12a55e77659c18e8d7b0332392f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->