### PR TITLE
fix: align nativeButton prop with rendered element on Base UI buttons

### DIFF
--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -51,6 +51,7 @@ export default async function NotFound() {
                                 <Button
                                     key={collection.id}
                                     render={<Link href={`/collection/${collection.slug}`} />}
+                                    nativeButton={false}
                                     variant="outline"
                                     size="sm"
                                     className="rounded-full"

--- a/src/components/layout/navbar/mobile-nav.tsx
+++ b/src/components/layout/navbar/mobile-nav.tsx
@@ -75,6 +75,7 @@ export function MobileNav({collections}: MobileNavProps) {
                                     className="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-md hover:bg-accent transition-colors"
                                 />
                             }
+                            nativeButton={false}
                             onClick={handleLinkClick}
                         >
                             <ShoppingBag className="h-5 w-5" />
@@ -98,6 +99,7 @@ export function MobileNav({collections}: MobileNavProps) {
                                                 className="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-md hover:bg-accent transition-colors"
                                             />
                                         }
+                                        nativeButton={false}
                                         onClick={handleLinkClick}
                                     >
                                         {collection.name}
@@ -120,6 +122,7 @@ export function MobileNav({collections}: MobileNavProps) {
                                         className="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-md hover:bg-accent transition-colors"
                                     />
                                 }
+                                nativeButton={false}
                                 onClick={handleLinkClick}
                             >
                                 <User className="h-5 w-5" />
@@ -132,6 +135,7 @@ export function MobileNav({collections}: MobileNavProps) {
                                         className="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-md hover:bg-accent transition-colors"
                                     />
                                 }
+                                nativeButton={false}
                                 onClick={handleLinkClick}
                             >
                                 <Package className="h-5 w-5" />
@@ -144,6 +148,7 @@ export function MobileNav({collections}: MobileNavProps) {
                                         className="flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-md hover:bg-accent transition-colors"
                                     />
                                 }
+                                nativeButton={false}
                                 onClick={handleLinkClick}
                             >
                                 <MapPin className="h-5 w-5" />

--- a/src/components/layout/navbar/navbar-user.tsx
+++ b/src/components/layout/navbar/navbar-user.tsx
@@ -21,7 +21,7 @@ export async function NavbarUser() {
 
     if (!customer) {
         return (
-            <Button render={<LoginButton isLoggedIn={false} />} nativeButton={false} variant="ghost" />
+            <Button render={<LoginButton isLoggedIn={false} />} variant="ghost" />
         );
     }
 
@@ -35,7 +35,7 @@ export async function NavbarUser() {
                 <DropdownMenuItem render={<Link href="/account/profile" />}>{t('profile')}</DropdownMenuItem>
                 <DropdownMenuItem render={<Link href="/account/orders" />}>{t('orders')}</DropdownMenuItem>
                 <DropdownMenuSeparator/>
-                <DropdownMenuItem render={<LoginButton isLoggedIn={true} />} />
+                <DropdownMenuItem render={<LoginButton isLoggedIn={true} />} nativeButton />
             </DropdownMenuContent>
         </DropdownMenu>
     );


### PR DESCRIPTION
## Summary

Fixes #27.

Base UI's `useButton` warns in dev when a button-like component's `nativeButton` value doesn't match the element actually rendered through the `render` prop:
- rendering a non-`<button>` (e.g. `<Link>`) requires `nativeButton={false}`
- rendering a real `<button>` requires `nativeButton` to be `true` (the per-component default varies)

Audited every `render={}` on button-like Base UI components repo-wide. All `components/ui/` files (shadcn-managed) were already correct; the mismatches were in app-owned files only.

## Changes

| File | Fix | Reason |
|---|---|---|
| `navbar-user.tsx` | Removed `nativeButton={false}` from `Button render={<LoginButton/>}` | `LoginButton` renders a real `<button>`; `Button` defaults `nativeButton=true` — the reported error |
| `navbar-user.tsx` | Added `nativeButton` to `DropdownMenuItem render={<LoginButton/>}` | `Menu.Item` defaults `nativeButton=false`, but `LoginButton` renders a `<button>` |
| `not-found.tsx` | Added `nativeButton={false}` to `Button render={<Link/>}` | was missing it |
| `mobile-nav.tsx` (×5) | Added `nativeButton={false}` to `SheetClose render={<Link/>}` | `Dialog.Close` defaults `true`, but renders anchors |

## Verification

- `tsc --noEmit` passes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/nextjs-starter-vendure/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784109357&installation_id=128408429&pr_number=32&repository=vendurehq%2Fnextjs-starter-vendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fnextjs-starter-vendure%2Fpull%2F32&signature=ba9f0f2fc2240f1d5ec9f195cce38edb69fa921ef90b156823c9578094428cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->