### PR TITLE
fix: hide option buttons for variants absent on the product

### DIFF
--- a/src/app/[locale]/product/[slug]/page.tsx
+++ b/src/app/[locale]/product/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { query } from '@/lib/vendure/api';
 import { GetProductDetailQuery } from '@/lib/vendure/queries';
 import { ProductImageCarousel } from '@/components/commerce/product-image-carousel';
 import { ProductInfo } from '@/components/commerce/product-info';
+import { getDisplayOptionGroups } from '@/lib/vendure/product-options';
 import { RelatedProducts } from '@/components/commerce/related-products';
 import {
     Accordion,
@@ -112,6 +113,10 @@ export default async function ProductDetailPage({params, searchParams}: PageProp
     // Get the primary collection (prefer deepest nested / most specific)
     const primaryCollection = product.collections?.find(c => c.parent?.id) ?? product.collections?.[0];
 
+    // Hide options that belong to a shared option group but have no variant on
+    // this product (Vendure 3.6 shared/global option groups).
+    const productForDisplay = {...product, optionGroups: getDisplayOptionGroups(product)};
+
     return (
         <>
             <div className="container mx-auto px-4 py-8 mt-16">
@@ -146,7 +151,7 @@ export default async function ProductDetailPage({params, searchParams}: PageProp
 
                     {/* Right Column: Product Info */}
                     <div>
-                        <ProductInfo product={product} searchParams={searchParamsResolved} currencyCode={currencyCode} />
+                        <ProductInfo product={productForDisplay} searchParams={searchParamsResolved} currencyCode={currencyCode} />
                     </div>
                 </div>
             </div>

--- a/src/components/commerce/product-info.tsx
+++ b/src/components/commerce/product-info.tsx
@@ -59,28 +59,12 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
     const [isPending, startTransition] = useTransition();
     const [isAdded, setIsAdded] = useState(false);
 
-    // Vendure 3.6 made option groups shared/global, so product.optionGroups can
-    // include options that have no matching variant on this product. Only keep the
-    // options that are actually used by one of this product's variants.
-    const optionGroups = useMemo(() => {
-        const usedOptionIds = new Set(
-            product.variants.flatMap((variant) => variant.options.map((opt) => opt.id)),
-        );
-
-        return product.optionGroups
-            .map((group) => ({
-                ...group,
-                options: group.options.filter((option) => usedOptionIds.has(option.id)),
-            }))
-            .filter((group) => group.options.length > 0);
-    }, [product.optionGroups, product.variants]);
-
     // Initialize selected options from URL
     const [selectedOptions, setSelectedOptions] = useState<Record<string, string>>(() => {
         const initialOptions: Record<string, string> = {};
 
         // Load from URL search params
-        optionGroups.forEach((group) => {
+        product.optionGroups.forEach((group) => {
             const paramValue = searchParams[group.code];
             if (typeof paramValue === 'string') {
                 // Find the option by code
@@ -101,7 +85,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
         }
 
         // If not all option groups have a selection, return null
-        if (Object.keys(selectedOptions).length !== optionGroups.length) {
+        if (Object.keys(selectedOptions).length !== product.optionGroups.length) {
             return null;
         }
 
@@ -111,7 +95,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
             const selectedOptionIds = Object.values(selectedOptions);
             return selectedOptionIds.every((optId) => variantOptionIds.includes(optId));
         });
-    }, [selectedOptions, product.variants, optionGroups]);
+    }, [selectedOptions, product.variants, product.optionGroups]);
 
     const handleOptionChange = (groupId: string, optionId: string) => {
         setSelectedOptions((prev) => ({
@@ -120,7 +104,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
         }));
 
         // Find the option group and option to get their codes
-        const group = optionGroups.find((g) => g.id === groupId);
+        const group = product.optionGroups.find((g) => g.id === groupId);
         const option = group?.options.find((opt) => opt.id === optionId);
 
         if (group && option) {
@@ -176,9 +160,9 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
             </div>
 
             {/* Option Groups */}
-            {optionGroups.length > 0 && (
+            {product.optionGroups.length > 0 && (
                 <div className="space-y-5">
-                    {optionGroups.map((group) => (
+                    {product.optionGroups.map((group) => (
                         <div key={group.id} className="space-y-3">
                             <Label className="text-base font-semibold">
                                 {group.name}
@@ -245,7 +229,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
                             <ShoppingCart className="mr-2 h-5 w-5"/>
                             {isPending
                                 ? t('adding')
-                                : !selectedVariant && optionGroups.length > 0
+                                : !selectedVariant && product.optionGroups.length > 0
                                     ? t('selectOptions')
                                     : !isInStock
                                         ? t('outOfStock')

--- a/src/components/commerce/product-info.tsx
+++ b/src/components/commerce/product-info.tsx
@@ -59,12 +59,28 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
     const [isPending, startTransition] = useTransition();
     const [isAdded, setIsAdded] = useState(false);
 
+    // Vendure 3.6 made option groups shared/global, so product.optionGroups can
+    // include options that have no matching variant on this product. Only keep the
+    // options that are actually used by one of this product's variants.
+    const optionGroups = useMemo(() => {
+        const usedOptionIds = new Set(
+            product.variants.flatMap((variant) => variant.options.map((opt) => opt.id)),
+        );
+
+        return product.optionGroups
+            .map((group) => ({
+                ...group,
+                options: group.options.filter((option) => usedOptionIds.has(option.id)),
+            }))
+            .filter((group) => group.options.length > 0);
+    }, [product.optionGroups, product.variants]);
+
     // Initialize selected options from URL
     const [selectedOptions, setSelectedOptions] = useState<Record<string, string>>(() => {
         const initialOptions: Record<string, string> = {};
 
         // Load from URL search params
-        product.optionGroups.forEach((group) => {
+        optionGroups.forEach((group) => {
             const paramValue = searchParams[group.code];
             if (typeof paramValue === 'string') {
                 // Find the option by code
@@ -85,7 +101,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
         }
 
         // If not all option groups have a selection, return null
-        if (Object.keys(selectedOptions).length !== product.optionGroups.length) {
+        if (Object.keys(selectedOptions).length !== optionGroups.length) {
             return null;
         }
 
@@ -95,7 +111,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
             const selectedOptionIds = Object.values(selectedOptions);
             return selectedOptionIds.every((optId) => variantOptionIds.includes(optId));
         });
-    }, [selectedOptions, product.variants, product.optionGroups]);
+    }, [selectedOptions, product.variants, optionGroups]);
 
     const handleOptionChange = (groupId: string, optionId: string) => {
         setSelectedOptions((prev) => ({
@@ -104,7 +120,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
         }));
 
         // Find the option group and option to get their codes
-        const group = product.optionGroups.find((g) => g.id === groupId);
+        const group = optionGroups.find((g) => g.id === groupId);
         const option = group?.options.find((opt) => opt.id === optionId);
 
         if (group && option) {
@@ -160,9 +176,9 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
             </div>
 
             {/* Option Groups */}
-            {product.optionGroups.length > 0 && (
+            {optionGroups.length > 0 && (
                 <div className="space-y-5">
-                    {product.optionGroups.map((group) => (
+                    {optionGroups.map((group) => (
                         <div key={group.id} className="space-y-3">
                             <Label className="text-base font-semibold">
                                 {group.name}
@@ -229,7 +245,7 @@ export function ProductInfo({product, searchParams, currencyCode}: ProductInfoPr
                             <ShoppingCart className="mr-2 h-5 w-5"/>
                             {isPending
                                 ? t('adding')
-                                : !selectedVariant && product.optionGroups.length > 0
+                                : !selectedVariant && optionGroups.length > 0
                                     ? t('selectOptions')
                                     : !isInStock
                                         ? t('outOfStock')

--- a/src/lib/vendure/product-options.ts
+++ b/src/lib/vendure/product-options.ts
@@ -1,0 +1,27 @@
+import type { ResultOf } from 'gql.tada';
+import type { GetProductDetailQuery } from './queries';
+
+type ProductDetail = NonNullable<ResultOf<typeof GetProductDetailQuery>['product']>;
+
+/**
+ * Vendure 3.6 made ProductOptionGroup/ProductOption shared and channel-aware
+ * (vendure#4469): a product's `optionGroups` now returns every option in the
+ * (possibly shared) group, including options for which this product has no
+ * variant. Rendering those directly produces "phantom" option buttons with no
+ * price, no stock status, and a permanently disabled add-to-cart.
+ *
+ * This returns the option groups reduced to the options actually used by one of
+ * the product's variants, dropping any group left with no options.
+ */
+export function getDisplayOptionGroups(product: ProductDetail): ProductDetail['optionGroups'] {
+    const usedOptionIds = new Set(
+        product.variants.flatMap((variant) => variant.options.map((option) => option.id)),
+    );
+
+    return product.optionGroups
+        .map((group) => ({
+            ...group,
+            options: group.options.filter((option) => usedOptionIds.has(option.id)),
+        }))
+        .filter((group) => group.options.length > 0);
+}


### PR DESCRIPTION
## Problem

Closes #30.

With Vendure **v3.6** (PR vendure-ecommerce/vendure#4469), `ProductOptionGroup` and `ProductOption` became **shared and channel-aware**. A group is now linked to products via a many-to-many relationship instead of being owned by a single product, and `Product.optionGroups[].options` returns **every** option in the (possibly shared) group — even options for which the current product has no variant.

The product page rendered its option buttons straight from `product.optionGroups[].options`, so options belonging to a shared group but with no variant on the current product appeared as phantom buttons: clicking them showed no price, no stock status, and left add-to-cart permanently disabled with no explanation.

## Fix

Derive the displayable options from the product's variants instead of trusting the raw option groups. A `useMemo` collects the option IDs actually used by `product.variants[].options`, filters each group's options to that set, and drops any group left empty. That filtered list now drives:

- option-group / button rendering
- URL-param state initialization (phantom option codes are ignored)
- the "all groups selected?" check in variant matching
- option-code lookup in the change handler
- the "select options" vs "add to cart" button label

No GraphQL query change was needed — `variants[].options[].id` was already fetched. This mirrors Vendure's own server-side "option in use" check (`variant.options.some(...)`).

## Behaviour

Given a shared group `S, M, L, XL` assigned to Product A (variants `S, M` only):

- **Before:** A's page shows S, M, L, XL — L/XL are dead buttons.
- **After:** A's page shows only S and M.

Single-variant and fully-variant products are unaffected.

## Verification

- `npm run check-types` — clean
- `npx eslint` on the changed file — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/nextjs-starter-vendure/pr/33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784115120&installation_id=128408429&pr_number=33&repository=vendurehq%2Fnextjs-starter-vendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fnextjs-starter-vendure%2Fpull%2F33&signature=d213ef341edcf031f48f426e700e5de59b963ae0ff91f57f0477ef7df5f54c92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->