### PR TITLE
fix(checkout): render payment method description as HTML

### DIFF
--- a/src/app/[locale]/checkout/steps/payment-step.tsx
+++ b/src/app/[locale]/checkout/steps/payment-step.tsx
@@ -43,9 +43,7 @@ export default function PaymentStep({ onComplete }: PaymentStepProps) {
                 <div className="flex-1">
                   <p className="font-medium">{method.name}</p>
                   {method.description && (
-                    <p className="text-sm text-muted-foreground mt-1">
-                      {method.description}
-                    </p>
+                    <p className="text-sm text-muted-foreground mt-1" dangerouslySetInnerHTML={{ __html: method.description }} />
                   )}
                 </div>
               </div>

--- a/src/app/[locale]/checkout/steps/review-step.tsx
+++ b/src/app/[locale]/checkout/steps/review-step.tsx
@@ -141,9 +141,7 @@ export default function ReviewStep({ onEditStep }: ReviewStepProps) {
               <div>
                 <p className="font-medium">{selectedPaymentMethod.name}</p>
                 {selectedPaymentMethod.description && (
-                  <p className="text-muted-foreground mt-1">
-                    {selectedPaymentMethod.description}
-                  </p>
+                  <p className="text-muted-foreground mt-1" dangerouslySetInnerHTML={{ __html: selectedPaymentMethod.description }} />
                 )}
               </div>
               <Button


### PR DESCRIPTION

## Summary

- Payment method descriptions in Vendure admin are saved as HTML by the rich 
  text editor (input is automatically wrapped in `<p>` tags)
- The checkout and review steps rendered these as plain strings, causing literal 
  `<p>` tags to appear on the storefront
- Fixed by using `dangerouslySetInnerHTML` in both affected components

## Affected files

- `src/app/[locale]/checkout/steps/payment-step.tsx`
- `src/app/[locale]/checkout/steps/review-step.tsx`

## Safety note

`dangerouslySetInnerHTML` is safe here because payment method descriptions are 
entered exclusively through the Vendure admin panel. No public/untrusted user 
input reaches this field.

## Test plan

- [ ] Add a payment method in Vendure admin with a plain text description
- [ ] Go to storefront checkout → payment step → verify description renders 
      as clean text (no `<p>` tags visible)
- [ ] Proceed to review step → verify same

<img width="1102" height="405" alt="afterPamyntTAg" src="https://github.com/user-attachments/assets/eaedaa36-5bf0-4429-82e2-1f8dc6e5447b" />

<img width="1019" height="292" alt="afterReviewtag" src="https://github.com/user-attachments/assets/24c9ecd4-d14a-4d51-a32a-0699d8c060f9" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/nextjs-starter-vendure/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784462581&installation_id=128408429&pr_number=36&repository=vendurehq%2Fnextjs-starter-vendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fnextjs-starter-vendure%2Fpull%2F36&signature=af9e55154ae6331e18176f16a71710c085e6618d089c35ddd666a814d0ed9f68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->