### PR TITLE
fix: declare graphql as a direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "date-fns": "^4.1.0",
         "embla-carousel-react": "^8.6.0",
         "gql.tada": "^1.9.0",
+        "graphql": "^16.11.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^1.0.1",
         "next": "^16.2.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
     "gql.tada": "^1.9.0",
+    "graphql": "^16.11.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.0.1",
     "next": "^16.2.1",


### PR DESCRIPTION
## Problem

`src/lib/vendure/api.ts` imports directly from `graphql`:

```ts
import {print} from 'graphql';
```

but `graphql` was not declared in `package.json` dependencies. Under npm, yarn and bun this works because `graphql` gets hoisted into the root `node_modules` as a transitive dependency of the `@vendure/*` packages in the sibling `apps/server` workspace.

Under pnpm's strict `node_modules` isolation there is no hoisting, so the storefront fails at dev/build time:

```
Module not found: Can't resolve 'graphql'
> 2 | import {print} from 'graphql';
```

This affects every project scaffolded via `pnpm dlx @vendure/create` with the storefront included.

## Fix

Declare `graphql` as a direct dependency. It's a genuine runtime dependency of the storefront regardless of hoisting behaviour, so it should be declared even where hoisting currently masks it.

The lockfile already resolved `graphql@16.12.0` transitively (via `gql.tada`), so this only adds it to the root `dependencies` — a minimal two-line change.

Closes #38

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/nextjs-starter-vendure/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786265003&installation_id=128408429&pr_number=39&repository=vendurehq%2Fnextjs-starter-vendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fnextjs-starter-vendure%2Fpull%2F39&signature=c80e8ecc66750fba2b5e939f59cb567a8928eec92c47860d7c6769ad06df8f5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->