### PR TITLE
docs(readme): document upgradeable architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
   Vendure Next.js Storefront Starter
 </h1>
 <h3 align="center">
-    A Next.js 16 storefront starter for Vendure headless commerce
+  A Next.js 16 storefront starter for Vendure headless commerce
 </h3>
 <p align="center">
- Use as a foundation to build upon, take inspiration from, or learn the ergonomics of the Vendure Shop API.
+  A source-owned, customizable storefront with a managed path for adopting upstream releases.
 </p>
 <h4 align="center">
   <a href="https://next.vendure.io">Demo</a> |
@@ -21,46 +21,60 @@
 ## Features
 
 **Authentication & Accounts**
+
 - Customer registration with email verification
 - Login/logout with session management
 - Password reset & change password
 - Email address updates with verification
 
 **Customer Account**
+
 - Profile management (name, email, password)
 - Address management (create, update, delete, set default)
 - Order history with pagination & detailed order views
 
 **Product Browsing**
+
 - Collections & featured products
 - Product detail pages with variants & galleries
 - Full-text search with faceted filtering
 - Pagination & sorting
 
 **Shopping Cart**
+
 - Add/remove items, adjust quantities
 - Promotion code support
 - Real-time cart updates with totals
 
 **Checkout**
+
 - Multi-step flow: shipping address, delivery method, payment, review
 - Saved address selection
 - Shipping method selection
 - Payment integration
 
 **Order Management**
+
 - Order confirmation page
 - Order tracking with status
 - Detailed order information
 
 **Internationalization**
+
 - Multi-language support via next-intl (English & German out of the box)
 - Multi-currency support with persistent currency selection
 - Locale-aware price formatting
 
+**Built to Customize and Upgrade**
+
+- Developer-owned source with no locked or generated application layer
+- Feature-oriented modules with enforced dependency boundaries
+- Colocated GraphQL operations and translations
+- Structured release manifests for reconciling upstream changes with local customizations
+
 ## Getting Started
 
-Copy the example environment file, configure your Vendure Shop API, install dependencies, and start the development server:
+You need a running Vendure server with its Shop API available. Copy the example environment, point `VENDURE_SHOP_API_URL` at that API, install dependencies, and start the storefront:
 
 ```bash
 cp .env.example .env.local
@@ -70,28 +84,58 @@ npm run dev
 
 Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
 
-The App Router files under `src/app` are intentionally thin. Storefront behavior and presentation live in vertical modules under `src/features`, cross-cutting integrations under `src/platform`, and store-specific composition under `src/site`.
+The environment template also documents optional channel, metadata, authentication header, and cache revalidation settings.
 
-See the [architecture guide](./docs/architecture.md) before adding a capability.
+## Architecture
 
-## Upgrading a Customized Storefront
+Every human-authored storefront file is yours to change. The source is organized to keep those changes local and make future upgrades easier to reconcile:
 
-This starter is designed to remain fully source-owned after cloning or forking. Tagged releases include structured integration intent so a human or coding agent can reconcile upstream changes with local customizations.
-See the [upgrade guide](./docs/upgrades.md) for initialization, managed upgrades, legacy onboarding, verification, and release authoring.
+```text
+src/
+  app/          Next.js route wiring only
+  config/       Store-wide configuration
+  features/     Vertical commerce capabilities
+  platform/     Next.js, i18n, revalidation, and Vendure integrations
+  site/         Store-specific composition, navigation, and branding
+  components/ui Generic design primitives
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Keep `src/app` files thin and put substantial behavior in the module that owns it. A feature exposes other modules through top-level files; its `components/` and `routes/` directories are private implementation details.
 
-## Learn More
+Read the [architecture guide](./docs/architecture.md) before adding a capability.
 
-To learn more about Next.js, take a look at the following resources:
+## Upgrading
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Tagged releases include structured integration intent so a human or coding agent can adopt upstream changes without silently overwriting storefront customizations.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+After creating a storefront from an immutable release tag, record its exact upstream provenance once:
 
-## Deploy on Vercel
+```bash
+npm run upgrade:init
+git add .vendure/storefront.json
+git commit -m "chore: initialize storefront provenance"
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+To prepare a later upgrade on a clean, dedicated branch:
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+npm run upgrade:prepare -- 1.1.0
+```
+
+The command creates a gitignored integration workspace containing the old and new upstream snapshots, release guidance, and a report template. Reconcile the changes, then follow the generated brief to verify and finalize the upgrade.
+
+See the [upgrade guide](./docs/upgrades.md) for the complete managed upgrade, legacy onboarding, and release-authoring workflows.
+
+## Development
+
+Run the same checks used by CI before submitting a change:
+
+```bash
+npm run upgrade:validate
+npm test
+npm run lint
+npm run check-types
+npm run build
+```
+
+Downstream-impacting pull requests require an upgrade note or an explicit exemption. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the contribution workflow.


### PR DESCRIPTION
## Summary

Updates the README to present the source-owned, upgradeable storefront model introduced on `main`.
Documents the module boundaries, provenance initialization, managed upgrade workflow, and required development checks.
Removes generic Create Next App guidance that no longer reflects how this repository is maintained.

## Validation

`npm run upgrade:validate`, `npm test`, `npm run lint`, `npm run check-types`, and `npm run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/nextjs-starter-vendure/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788093113&installation_model_id=20193&pr_number=42&repository=vendurehq%2Fnextjs-starter-vendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fnextjs-starter-vendure%2Fpull%2F42&signature=6c2fc9e1b8eb100f260410d55e9667dc8399d90b02fca408b17ec91b51c508a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->